### PR TITLE
Fix adding the version information in the makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,9 +28,9 @@ VERSION ?= $(shell git symbolic-ref -q --short HEAD || git describe --tags --exa
 
 BIN_TARGET=$(BIN_FOLDER)$(BIN_NAME)-$(VERSION)$(EXE)
 
-export FLAGS += -X "main.Version=$(VERSION)"
-export FLAGS += -X "main.GitCommit=$(GIT_COMMIT)"
-export FLAGS += -X "main.BuildTime=$(shell date)"
+export FLAGS += -X "main.version=$(VERSION)"
+export FLAGS += -X "main.commit=$(GIT_COMMIT)"
+export FLAGS += -X "main.date=$(shell date)"
 
 all: test build
 


### PR DESCRIPTION
Previously the version information would look like this

```
$ ./build/red-cli-main --version
red-cli version 0.0.0-dev
Git Commit:
Build time:
```

Now it looks like this
```
$ ./build/red-cli-main --version
red-cli version main
Git Commit: fe6331a4928e5f3892712f45702e6344ed35dc79
Build time: Mi 12 Mär 2025 17:09:54 CET
```