### PR TITLE
Don't show empty git commit and build time in version output

### DIFF
--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/MrJeffLarry/redmine-cli/internal/cmd/auth"
 	cmdConfig "github.com/MrJeffLarry/redmine-cli/internal/cmd/config"
@@ -31,12 +32,20 @@ func CmdInit(Version, GitCommit, BuildTime string) *config.Red_t {
 	r := config.InitConfig()
 
 	r.Term = terminal.New(nil, nil, nil)
+	version := Version
+	if strings.TrimSpace(GitCommit) != "" {
+		version += "\nGit Commit: " + GitCommit
+	}
+
+	if strings.TrimSpace(BuildTime) != "" {
+		version += "\nBuild Time: " + BuildTime
+	}
 
 	r.Cmd = &cobra.Command{
 		Use:           "red-cli <command> <subcommand> [flags]",
 		Short:         "Redmine CLI",
 		Long:          `Redmine CLI for integration with Redmine API`,
-		Version:       Version + "\nGit Commit: " + GitCommit + "\nBuild time: " + BuildTime,
+		Version:       version,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Run:           func(cmd *cobra.Command, args []string) { cmd.Help() },


### PR DESCRIPTION
If the build script doesn't pass the git commit and the build time we hide it.

When building with:  `go build -ldflags "-s -w -X main.version=0.1.11-arch" -o build/red-cli ./cmd/red/`

Previous output:

    red-cli version 0.1.10-arch
    Git Commit:
    Build time:

New output:

    red-cli version 0.1.11-arch

See also discussion at #82